### PR TITLE
remove undefined declare as a parameter.

### DIFF
--- a/jquery.ba-throttle-debounce.js
+++ b/jquery.ba-throttle-debounce.js
@@ -60,7 +60,7 @@
 // the `Cowboy` namespace. Usage will be exactly the same, but instead of
 // $.method() or jQuery.method(), you'll need to use Cowboy.method().
 
-(function(window,undefined){
+(function(window){
   '$:nomunge'; // Used by YUI compressor.
   
   // Since jQuery really isn't required for this plugin, use `jQuery` as the

--- a/shared/jquery-1.4.2.js
+++ b/shared/jquery-1.4.2.js
@@ -13,7 +13,7 @@
  *
  * Date: Sat Feb 13 22:33:48 2010 -0500
  */
-(function( window, undefined ) {
+(function(window) {
 
 // Define a local copy of jQuery
 var jQuery = function( selector, context ) {


### PR DESCRIPTION
JavaScript has special identifiers, undefined. so remove undefined declared as parameter in the functions.